### PR TITLE
announce BIO International 2025

### DIFF
--- a/_news/36-page-workshop-announcement.md
+++ b/_news/36-page-workshop-announcement.md
@@ -1,6 +1,0 @@
----
-title: SATELLITE WORKSHOPS AT PAGE 2025
-description: Join ESQlabs team at PAGE to learn more about PBPK modeling and the new features of Version 12 of OSP Suite.
-icon: book
-github_url: Forum/discussions/1934
----

--- a/_news/37-bio-international-announcement.md
+++ b/_news/37-bio-international-announcement.md
@@ -1,0 +1,6 @@
+---
+title: Satellite Workshop at BIO International 2025
+description: Join ESQlabs at the BIO International conference in Boston on June 20th and learn more about how to modularize PBPK-QAP frameworks with the new V12 OSP release.
+icon: book
+github_url: Forum/discussions/1953
+---


### PR DESCRIPTION
I replaced the PAGE announcement instead of rotating it because I think the item that would have been rotated is still relevant to keep.