### PR TITLE
Fixes #152 Add "Working with GitHub" section in the FAQ

### DIFF
--- a/_includes/faq.md
+++ b/_includes/faq.md
@@ -300,7 +300,7 @@ Yes. The project is built on three core pillars:
 - **Open Science** — The community jointly develops scientific concepts, applications, and best practices.
 
 ---
-## 9. GitHub for Beginners (Especially Non‑Programmers)
+## 9. GitHub for Beginners (Especially Non-Programmers)
 
 ### What is GitHub, and how can I learn to use it?
 


### PR DESCRIPTION
Fixes #152 Add "Working with GitHub" section in the FAQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new beginner-friendly "GitHub for Beginners (Especially Non-Programmers)" FAQ section covering GitHub basics, Markdown, GitHub Desktop, releases, video tutorials, and resources.
  * Inserted a separator and adjusted subsequent FAQ section numbering to accommodate the new content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->