### PR TITLE
Fixes #154 Links not clickable in the "Working with GitHub" section in the FAQ

### DIFF
--- a/_includes/faq.md
+++ b/_includes/faq.md
@@ -309,12 +309,15 @@ GitHub can be used without being a programmer - think of it as a place to **stor
 - Essentials (Start Here)
   - What is GitHub, in plain language?
     - GitHub is a website where people and teams keep files in **repositories** (folders/projects), track changes over time, and collaborate (comments, reviews, suggestions).
+    
   - What should I learn first?
     - Start with a hands-on “Hello World” walkthrough, then learn the basic collaboration workflow used across GitHub.
-    - Essentials: **Hello World Example**  
-      https://docs.github.com/en/get-started/start-your-journey/hello-world
-    - Bit more details: **GitHub flow** (the usual “branch → change → pull request → review → merge” pattern)  
-      https://docs.github.com/en/get-started/using-github/github-flow
+    
+    - Essentials: **[Hello World Example](https://docs.github.com/en/get-started/start-your-journey/hello-world)**
+    
+    - Bit more details: **[GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow)** 
+    (the usual “branch → change → pull request → review → merge” pattern)  
+    
   - What do “issues” and “pull requests” mean? (Non-programmer translation)
     - **Issue**: a task, question, or idea thread (like a to-do item with discussion).
     - **Pull request (PR)**: “I made changes; please review and add them.” It’s a review + approval step before changes become official.
@@ -324,50 +327,38 @@ GitHub can be used without being a programmer - think of it as a place to **stor
 - Mastering Markdown (Writing on GitHub)
   - Do I need to learn Markdown?
     - If you write README files, documentation, **qualification reports**, notes, or project pages on GitHub: yes - Markdown is the easiest way to format text (headings, lists, links, checklists).
-    - **Basic writing and formatting syntax**  
-      https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
+    - **[Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)**
   - What “advanced formatting” is worth knowing?
     - Once you know the basics, you can level up your documents with tables, callouts, and other formatting tools.
-    - **Working with advanced formatting**  
-      https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting
-    - **Organizing information with tables**  
-      https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables
+    - **[Working with advanced formatting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting)**
+    - **[Organizing information with tables](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)**
     - Optional deep dives:
-      - **Writing mathematical expressions**  
-        https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
-      - **Creating diagrams**  
-        https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams
+      - **[Writing mathematical expressions](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions)**
+      - **[Creating diagrams](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)**
 
 ### Can GitHub be used without complicated command line tools?
 
 - “No Command Line” Option: GitHub Desktop
   - Can I use GitHub without the command line?
     - Yes. **GitHub Desktop** is a beginner-friendly app for working with repositories using buttons and menus (clone, commit, push, pull, branch).
-    - **Getting started with GitHub Desktop**  
-      https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop
-    - **All GitHub Desktop documentation topics**  
-      https://docs.github.com/en/desktop
+    - **[Getting started with GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop)**
+    - **[All GitHub Desktop documentation topics](https://docs.github.com/en/desktop)**
 
 ### What is a Release, and how do I create one in a GitHub repository?
 
 - Releases (Sharing Downloadable Versions)
   - What is a “release” and why would I use it?
     - A **release** is a published snapshot of a repository—useful for sharing a “version” people can download (documents, templates, packaged files, etc.). Releases are often paired with tags like `v1.0`.
-    - **Managing releases in a repository**  
-      https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
+    - **[Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)**
 
 ### Where can I find video tutorials on how to use GitHub and GitHub Desktop?
 
 - Optional: Video Tutorials
   - If you prefer learning by watching:
-    - **"GitHub for Beginners" (GitHub’s channel playlist/video)**  
-      https://www.youtube.com/watch?v=-RZ03WHqkaY&list=PL0lo9MOBetEFcp4SCWinBdpml9B2U25-f&index=3
-    - **How to Use GitHub Desktop | Beginner’s Step-by-Step GitHub GUI Tutorial**  
-      https://www.youtube.com/watch?v=AYJQi6TyPyU
-    - **GitHub Tutorial for Beginners**  
-      https://www.youtube.com/watch?v=v5gnvDUWqFM
-    - **How to Use Git & GitHub Desktop Tutorial for Beginners**  
-      https://www.youtube.com/watch?v=MaqVvXv6zrU
+    - **[GitHub for Beginners (GitHub’s channel playlist)](https://www.youtube.com/watch?v=-RZ03WHqkaY&list=PL0lo9MOBetEFcp4SCWinBdpml9B2U25-f&index=3)**
+    - **[How to Use GitHub Desktop | Beginner’s Step-by-Step GitHub GUI Tutorial](https://www.youtube.com/watch?v=AYJQi6TyPyU)**
+    - **[GitHub Tutorial for Beginners](https://www.youtube.com/watch?v=v5gnvDUWqFM)**
+    - **[How to Use Git & GitHub Desktop Tutorial for Beginners](https://www.youtube.com/watch?v=MaqVvXv6zrU)**  
 
 ---
 


### PR DESCRIPTION
Fixes #154 Links not clickable "Working with GitHub" section in the FAQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Converted plain URLs to formatted hyperlinks with descriptive text throughout FAQ for improved readability.
  * Enhanced spacing and expanded FAQ sections covering GitHub basics and Markdown formatting topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->