### PR TITLE
Fixes #156 FAQ content duplication and improves URL structure

### DIFF
--- a/_includes/alt_header.html
+++ b/_includes/alt_header.html
@@ -3,7 +3,7 @@
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header">
       <a class="navbar-brand" href="{{ '/' | relative_url }}">
-        <img alt="Open Systems Pharmacology" class="logo" src="img/osp_logo.png">
+        <img alt="Open Systems Pharmacology" class="logo" src="{{ '/img/osp_logo.png' | relative_url }}">
       </a>
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#osp-navbar-collapse">
         <span class="sr-only">Toggle navigation</span>
@@ -33,8 +33,8 @@
         </li>
         <li><a href="{{ '#team' | relative_url }}">Management Team</a></li>
         <li><a href="{{ '#newsletter' | relative_url }}">Newsletter</a></li>
-        <li><a href="{{ '/conference.html' | relative_url }}">Conference</a></li>
-        <li><a href="{{ '/faq.html' | relative_url }}">FAQ</a></li>
+        <li><a href="{{ '/conference/' | relative_url }}">Conference</a></li>
+        <li><a href="{{ '/faq/' | relative_url }}">FAQ</a></li>
       </ul>
     </div>
   </div>

--- a/_includes/faq.md
+++ b/_includes/faq.md
@@ -300,65 +300,60 @@ Yes. The project is built on three core pillars:
 - **Open Science** — The community jointly develops scientific concepts, applications, and best practices.
 
 ---
-## 9. GitHub for Beginners (Especially Non-Programmers)
+## 9. GitHub for Beginners
 
-### What is GitHub, and how can I learn to use it?
+### What is GitHub?
 
-GitHub can be used without being a programmer - think of it as a place to **store, organize, collaborate on, and publish files** (documents, notes, designs, datasets, etc.), with a clear history of changes.
+GitHub is a website where people and teams keep files in **repositories** (folders/projects), track changes over time, and collaborate (comments, reviews, suggestions). You don't need to be a programmer to use it — think of it as a place to **store, organize, collaborate on, and publish files** (documents, notes, designs, datasets, etc.), with a clear history of changes.
 
-- Essentials (Start Here)
-  - What is GitHub, in plain language?
-    - GitHub is a website where people and teams keep files in **repositories** (folders/projects), track changes over time, and collaborate (comments, reviews, suggestions).
-    
-  - What should I learn first?
-    - Start with a hands-on “Hello World” walkthrough, then learn the basic collaboration workflow used across GitHub.
-    
-    - Essentials: **[Hello World Example](https://docs.github.com/en/get-started/start-your-journey/hello-world)**
-    
-    - Bit more details: **[GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow)** 
-    (the usual “branch → change → pull request → review → merge” pattern)  
-    
-  - What do “issues” and “pull requests” mean? (Non-programmer translation)
-    - **Issue**: a task, question, or idea thread (like a to-do item with discussion).
-    - **Pull request (PR)**: “I made changes; please review and add them.” It’s a review + approval step before changes become official.
+### What should I learn first?
 
-### What is (GitHub-flavored) Markdown, and how can I learn it?
+Start with a hands-on "Hello World" walkthrough, then learn the basic collaboration workflow used across GitHub.
 
-- Mastering Markdown (Writing on GitHub)
-  - Do I need to learn Markdown?
-    - If you write README files, documentation, **qualification reports**, notes, or project pages on GitHub: yes - Markdown is the easiest way to format text (headings, lists, links, checklists).
-    - **[Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)**
-  - What “advanced formatting” is worth knowing?
-    - Once you know the basics, you can level up your documents with tables, callouts, and other formatting tools.
-    - **[Working with advanced formatting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting)**
-    - **[Organizing information with tables](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)**
-    - Optional deep dives:
-      - **[Writing mathematical expressions](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions)**
-      - **[Creating diagrams](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)**
+- **[Hello World Example](https://docs.github.com/en/get-started/start-your-journey/hello-world)** — The essential first tutorial
+- **[GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow)** — The usual "branch → change → pull request → review → merge" pattern
 
-### Can GitHub be used without complicated command line tools?
+### What do "issues" and "pull requests" mean?
 
-- “No Command Line” Option: GitHub Desktop
-  - Can I use GitHub without the command line?
-    - Yes. **GitHub Desktop** is a beginner-friendly app for working with repositories using buttons and menus (clone, commit, push, pull, branch).
-    - **[Getting started with GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop)**
-    - **[All GitHub Desktop documentation topics](https://docs.github.com/en/desktop)**
+These are GitHub's core collaboration tools:
 
-### What is a Release, and how do I create one in a GitHub repository?
+- **Issue**: A task, question, or idea thread (like a to-do item with discussion).
+- **Pull request (PR)**: "I made changes; please review and add them." It's a review + approval step before changes become official.
 
-- Releases (Sharing Downloadable Versions)
-  - What is a “release” and why would I use it?
-    - A **release** is a published snapshot of a repository—useful for sharing a “version” people can download (documents, templates, packaged files, etc.). Releases are often paired with tags like `v1.0`.
-    - **[Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)**
+### What is Markdown and do I need to learn it?
 
-### Where can I find video tutorials on how to use GitHub and GitHub Desktop?
+If you write README files, documentation, **qualification reports**, notes, or project pages on GitHub: yes — Markdown is the easiest way to format text (headings, lists, links, checklists).
 
-- Optional: Video Tutorials
-  - If you prefer learning by watching:
-    - **[GitHub for Beginners (GitHub’s channel playlist)](https://www.youtube.com/watch?v=-RZ03WHqkaY&list=PL0lo9MOBetEFcp4SCWinBdpml9B2U25-f&index=3)**
-    - **[How to Use GitHub Desktop | Beginner’s Step-by-Step GitHub GUI Tutorial](https://www.youtube.com/watch?v=AYJQi6TyPyU)**
-    - **[GitHub Tutorial for Beginners](https://www.youtube.com/watch?v=v5gnvDUWqFM)**
-    - **[How to Use Git & GitHub Desktop Tutorial for Beginners](https://www.youtube.com/watch?v=MaqVvXv6zrU)**  
+**Getting started:**
+- **[Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)**
+
+**Advanced formatting:**
+- **[Working with advanced formatting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting)**
+- **[Organizing information with tables](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)**
+- **[Writing mathematical expressions](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions)**
+- **[Creating diagrams](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)**
+
+### Can I use GitHub without the command line?
+
+Yes. **GitHub Desktop** is a beginner-friendly app for working with repositories using buttons and menus (clone, commit, push, pull, branch).
+
+- **[Getting started with GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop)**
+- **[All GitHub Desktop documentation topics](https://docs.github.com/en/desktop)**
+
+### What is a release?
+
+A **release** is a published snapshot of a repository — useful for sharing a "version" people can download (documents, templates, packaged files, etc.). Releases are often paired with tags like `v1.0`.
+
+- **[Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)**
+
+### Where can I find video tutorials?
+
+If you prefer learning by watching:
+
+- **[GitHub for Beginners (GitHub's channel playlist)](https://www.youtube.com/watch?v=-RZ03WHqkaY&list=PL0lo9MOBetEFcp4SCWinBdpml9B2U25-f&index=3)**
+- **[How to Use GitHub Desktop - Beginner's Step-by-Step GitHub GUI Tutorial](https://www.youtube.com/watch?v=AYJQi6TyPyU)**
+- **[GitHub Tutorial for Beginners](https://www.youtube.com/watch?v=v5gnvDUWqFM)**
+- **[How to Use Git & GitHub Desktop Tutorial for Beginners](https://www.youtube.com/watch?v=MaqVvXv6zrU)**
 
 ---
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header page-scroll">
       <a class="navbar-brand page-scroll" href="#intro">
-        <img alt="Open Systems Pharmacology" class="logo" src="img/osp_logo.png">
+        <img alt="Open Systems Pharmacology" class="logo" src="{{ '/img/osp_logo.png' | relative_url }}">
       </a>
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#osp-navbar-collapse">
         <span class="sr-only">Toggle navigation</span>
@@ -33,8 +33,8 @@
         </li>
         <li><a class="page-scroll" href="{{ '#team' | relative_url }}">Management Team</a></li>
         <li><a class="page-scroll" href="{{ '#newsletter' | relative_url }}">Newsletter</a></li>
-        <li><a href="{{ '/conference.html' | relative_url }}">Conference</a></li>
-        <li><a href="{{ '/faq.html' | relative_url }}">FAQ</a></li>
+        <li><a href="{{ '/conference/' | relative_url }}">Conference</a></li>
+        <li><a href="{{ '/faq/' | relative_url }}">FAQ</a></li>
       </ul>
     </div>
   </div>

--- a/_layouts/conference.html
+++ b/_layouts/conference.html
@@ -15,13 +15,13 @@
 
   {% include ga.html %}
 
-  <script type="text/javascript" src="js/jquery.1.8.3.min.js"></script>
-  <script type="text/javascript" src="js/bootstrap.js"></script>
-  <script type="text/javascript" src="js/jquery-scrolltofixed.js"></script>
-  <script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
-  <script type="text/javascript" src="js/aos.js"></script>
-  <script type="text/javascript" src="js/site.js"></script>
-  <script type="text/javascript" src="js/slick.min.js"></script>
+  <script type="text/javascript" src="{{ '/js/jquery.1.8.3.min.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/bootstrap.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/jquery-scrolltofixed.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/jquery.easing.1.3.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/aos.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/site.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/slick.min.js' | relative_url }}"></script>
 </body>
 
 </html>

--- a/_layouts/faq.html
+++ b/_layouts/faq.html
@@ -55,13 +55,13 @@
 
   {% include ga.html %}
 
-  <script type="text/javascript" src="js/jquery.1.8.3.min.js"></script>
-  <script type="text/javascript" src="js/bootstrap.js"></script>
-  <script type="text/javascript" src="js/jquery-scrolltofixed.js"></script>
-  <script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
-  <script type="text/javascript" src="js/aos.js"></script>
-  <script type="text/javascript" src="js/site.js"></script>
-  <script type="text/javascript" src="js/slick.min.js"></script>
+  <script type="text/javascript" src="{{ '/js/jquery.1.8.3.min.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/bootstrap.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/jquery-scrolltofixed.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/jquery.easing.1.3.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/aos.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/site.js' | relative_url }}"></script>
+  <script type="text/javascript" src="{{ '/js/slick.min.js' | relative_url }}"></script>
 
   <script>
   (function() {
@@ -112,8 +112,8 @@
     const tempDiv = document.createElement('div');
     tempDiv.innerHTML = rawContent.innerHTML;
 
-    // Find all h2 elements (categories) and h3 elements (questions)
-    const elements = tempDiv.querySelectorAll('h1, h2, h3, p, ul, ol, table, pre, hr');
+    // Find only direct children elements (not nested lists)
+    const elements = Array.from(tempDiv.children);
 
     let categories = [];
     let currentCategory = null;
@@ -290,22 +290,30 @@
 
     const observerOptions = {
       root: null,
-      rootMargin: '-100px 0px -50% 0px',
+      rootMargin: '-80px 0px -70% 0px',
       threshold: 0
     };
 
     const observer = new IntersectionObserver((entries) => {
+      // Find the entry closest to the top of the viewport
+      let topEntry = null;
       entries.forEach(entry => {
         if (entry.isIntersecting) {
-          const id = entry.target.getAttribute('id');
-          navLinks.forEach(link => {
-            link.classList.remove('active');
-            if (link.getAttribute('href') === '#' + id) {
-              link.classList.add('active');
-            }
-          });
+          if (!topEntry || entry.boundingClientRect.top < topEntry.boundingClientRect.top) {
+            topEntry = entry;
+          }
         }
       });
+
+      if (topEntry) {
+        const id = topEntry.target.getAttribute('id');
+        navLinks.forEach(link => {
+          link.classList.remove('active');
+          if (link.getAttribute('href') === '#' + id) {
+            link.classList.add('active');
+          }
+        });
+      }
     }, observerOptions);
 
     categoryElements.forEach(category => {
@@ -319,6 +327,10 @@
         const targetId = link.getAttribute('href');
         const target = document.querySelector(targetId);
         if (target) {
+          // Immediately update active state on click
+          navLinks.forEach(l => l.classList.remove('active'));
+          link.classList.add('active');
+
           target.scrollIntoView({ behavior: 'smooth' });
         }
       });

--- a/conference.html
+++ b/conference.html
@@ -1,0 +1,14 @@
+---
+---
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="{{ '/conference/' | absolute_url }}">
+  <meta http-equiv="refresh" content="0; url={{ '/conference/' | relative_url }}">
+</head>
+<body>
+  <p>Redirecting to <a href="{{ '/conference/' | relative_url }}">/conference/</a>...</p>
+</body>
+</html>

--- a/conference.md
+++ b/conference.md
@@ -3,4 +3,5 @@
 # Edit theme's home layout instead if you wanna make some changes
 # See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 layout: conference
+permalink: /conference/
 ---

--- a/faq.md
+++ b/faq.md
@@ -3,4 +3,5 @@
 # Edit theme's home layout instead if you wanna make some changes
 # See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 layout: faq
+permalink: /faq/
 ---


### PR DESCRIPTION
## Summary
- Fix JavaScript parser to only process direct children elements, preventing nested lists from being duplicated in the FAQ output
- Restructure "GitHub for Beginners" section with proper H3 questions instead of deeply nested lists
- Add clean URLs (`/faq/` and `/conference/`) with redirects for backwards compatibility
- Fix relative paths for JS/CSS/images using Jekyll `relative_url` filter

## Test plan
- [ ] Verify FAQ page loads correctly at `/faq/`
- [ ] Verify no content duplication in the GitHub for Beginners section
- [ ] Verify sidebar navigation works and highlights correctly when scrolling
- [ ] Verify conference page loads correctly at `/conference/`
- [ ] Verify `/conference.html` redirects to `/conference/`
- [ ] Verify logo and all assets load correctly on both pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced FAQ navigation with improved scroll tracking for active section highlighting.

* **Documentation**
  * Reorganized and streamlined "GitHub for Beginners" FAQ section for clearer content flow and readability.

* **Chores**
  * Optimized URL structure with directory-style paths for improved site navigation.
  * Standardized asset path handling for better deployment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->