### PR TITLE
Update conference registration link to EventPage URL

### DIFF
--- a/_includes/conference.html
+++ b/_includes/conference.html
@@ -58,7 +58,7 @@
           <div class="conference-section col-lg-12 col-md-12">
             <p>
               <a class="btn btn-info" target="_blank" rel="noopener noreferrer"
-                href="https://www.eventleaf.com/Attendee/Attendee/RegistrationTypeSelection?EId=O3Aw6hfGQb%2FOfI3ULSNaAw%3D%3D&SId=ea5265bd-fd5a-4d47-a2f5-780e9660ddf4">
+                href="https://www.eventleaf.com/Attendee/Attendee/EventPage?eId=O3Aw6hfGQb%2FOfI3ULSNaAw%3D%3D">
                 Register here</a>
             </p>
           </div>


### PR DESCRIPTION
## Summary
- Replaces the conference registration button link in `_includes/conference.html` with the general EventPage URL (`EventPage?eId=...`) instead of the deep link to `RegistrationTypeSelection` with a specific session ID.

## Test plan
- [x] Verify the "Register here" button on the conference page navigates to the EventPage in Eventleaf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the registration link to direct to the correct EventLeaf event page for the Antwerp September 2026 conference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/open-systems-pharmacology.github.io/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->